### PR TITLE
[Logs+Metrics UI] Fix type inference broken by the TS 3.9 upgrade

### DIFF
--- a/x-pack/plugins/infra/public/components/logging/log_text_stream/column_headers.tsx
+++ b/x-pack/plugins/infra/public/components/logging/log_text_stream/column_headers.tsx
@@ -77,8 +77,8 @@ const LogColumnHeader: React.FunctionComponent<{
   </LogColumnHeaderWrapper>
 );
 
-const LogColumnHeadersWrapper = euiStyled.div.attrs(() => ({
-  role: 'row',
+const LogColumnHeadersWrapper = euiStyled.div.attrs((props) => ({
+  role: props.role ?? 'row',
 }))`
   align-items: stretch;
   display: flex;
@@ -93,8 +93,8 @@ const LogColumnHeadersWrapper = euiStyled.div.attrs(() => ({
   z-index: 1;
 `;
 
-const LogColumnHeaderWrapper = euiStyled(LogEntryColumn).attrs(() => ({
-  role: 'columnheader',
+const LogColumnHeaderWrapper = euiStyled(LogEntryColumn).attrs((props) => ({
+  role: props.role ?? 'columnheader',
 }))`
   align-items: center;
   display: flex;


### PR DESCRIPTION
## Summary

This fixes the type inference of a styled component wrapper, which stopped working correctly in TypeScript 3.9.