### PR TITLE
Fixes type error for newer TypeScript

### DIFF
--- a/x-pack/test/detection_engine_api_integration/utils.ts
+++ b/x-pack/test/detection_engine_api_integration/utils.ts
@@ -280,7 +280,7 @@ export const getSimpleRuleAsNdjson = (ruleIds: string[]): Buffer => {
  * testing upload features.
  * @param rule The rule to convert to ndjson
  */
-export const ruleToNdjson = (rule: Partial<RulesSchema>): Buffer => {
+export const ruleToNdjson = (rule: Partial<CreateRulesSchema>): Buffer => {
   const stringified = JSON.stringify(rule);
   return Buffer.from(`${stringified}\n`);
 };


### PR DESCRIPTION
Tested this with:

```
node scripts/type_check.js --project x-pack/test/tsconfig.json
```